### PR TITLE
⬆️ update tslint-rulebase so we dont need valid jsdoc

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@essential-projects/tslint-config",
-  "version": "1.0.0-rc3",
+  "version": "1.0.0-rc4",
   "description": "tslint config for the process-engine",
   "main": "index.js",
   "repository": {
@@ -13,7 +13,7 @@
     "url": "https://github.com/ProcessEngineJS/tslint-config/issues"
   },
   "dependencies": {
-    "tslint-eslint-config-5minds": "^1.0.1"
+    "tslint-eslint-config-5minds": "^1.0.3"
   },
   "peerDependencies": {
     "tslint": "^5.1.0",


### PR DESCRIPTION
## What did you change?

This updates the 5minds-tslint-eslint-config dependency that this package is based on, so that TSLint stops screaming at us, if we omit types in our typedoc documentation (see https://github.com/5minds/typescript-guidelines/pull/15)

## How can others test the changes?

Write some typedoc-documentation and see how tslint is not shouting at you

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
